### PR TITLE
Refresh block template periodically with mutex

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -9,6 +9,7 @@ const async = require('async');
 const net = require('net');
 const tls = require('tls');
 const fs = require('fs');
+const AsyncLock = require('async-lock');
 
 let nonceCheck = new RegExp("^[0-9a-f]{8}$");
 let bannedIPs = [];
@@ -18,6 +19,7 @@ let pastBlockTemplates = global.support.circularBuffer(4);
 let activeMiners = [];
 let activeMinerCount = [];
 let activeBlockTemplate;
+let activeBlockTemplateUpdated = 0;
 let workerList = [];
 let httpResponse = ' 200 OK\nContent-Type: text/plain\nContent-Length: 18\n\nMining Pool Online';
 let threadName;
@@ -25,7 +27,7 @@ let minerCount = [];
 let BlockTemplate = global.coinFuncs.BlockTemplate;
 let hexMatch = new RegExp("^[0-9a-f]+$");
 let totalShares = 0, trustedShares = 0, normalShares = 0, invalidShares = 0;
-
+let lock = new AsyncLock();
 
 Buffer.prototype.toByteArray = function () {
     return Array.prototype.slice.call(this, 0);
@@ -170,12 +172,21 @@ function templateUpdate(repeating) {
             });
         },
         function (currentBlockHeight, callback) {
-            if (activeBlockTemplate && activeBlockTemplate.height === currentBlockHeight) {
+            //set template to expire every 30 seconds to balance CPU usage
+            let refreshTemplate = false;
+            lock.acquire(activeBlockTemplateUpdated, function() {
+                if (Date.now() - activeBlockTemplateUpdated >= 30000)
+                    refreshTemplate = true;
+            });
+            if (activeBlockTemplate && activeBlockTemplate.height === currentBlockHeight && !refreshTemplate) {
                 callback(null, activeBlockTemplate.height);
             } else {
                 global.coinFuncs.getBlockTemplate(global.config.pool.address, function (rpcResponse) {
                     if (rpcResponse && typeof rpcResponse.result !== 'undefined') {
                         rpcResponse = rpcResponse.result;
+                        lock.acquire(activeBlockTemplateUpdated, function() {
+                            activeBlockTemplateUpdated = Date.now();
+                        });                        
                         if (!activeBlockTemplate || rpcResponse.height > activeBlockTemplate.height) {
                             debug(threadName + "New block template found at " + rpcResponse.height + " height");
                             if (cluster.isMaster) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.1.4",
+    "async-lock": "1.1.2",
     "bignum": "^0.12.5",
     "bluebird": "3.4.7",
     "body-parser": "^1.16.0",


### PR DESCRIPTION
If the block template is not periodically refreshed, blocks are mined "in the past" using a stale timestamp, and fewer transactions are included in the block.

The addition of a mutex on the fetching and updating of the block template significantly reduces concurrent (and unnecessary) queries to the daemon.