### PR TITLE
update cn variant to v4 for block version 6

### DIFF
--- a/lib/coins/lthn.js
+++ b/lib/coins/lthn.js
@@ -195,7 +195,11 @@ function Coin(data){
 
     this.cryptoNight = function(convertedBlob) {
         let cn_variant = convertedBlob[0] >= 4 ? (convertedBlob[0] >= 6 ? convertedBlob[0] - 2 : convertedBlob[0] - 3) : 0;
-        return cnHashing.cryptonight(convertedBlob, cn_variant);
+        if (cn_variant >= 4) { 
+            return cnHashing.cryptonight(convertedBlob, cn_variant, this.height);
+        } else {
+            return cnHashing.cryptonight(convertedBlob, cn_variant);
+        }
     };
 
 }

--- a/lib/coins/lthn.js
+++ b/lib/coins/lthn.js
@@ -194,7 +194,7 @@ function Coin(data){
     };
 
     this.cryptoNight = function(convertedBlob) {
-        let cn_variant = convertedBlob[0] >= 4 ? convertedBlob[0] - 3 : 0;
+        let cn_variant = convertedBlob[0] >= 4 ? (convertedBlob[0] >= 6 ? convertedBlob[0] - 2 : convertedBlob[0] - 3) : 0;
         return cnHashing.cryptonight(convertedBlob, cn_variant);
     };
 


### PR DESCRIPTION
Current code will attempt to use variant 3. This fix adds 1 to the variant version for block major version 6 and later.